### PR TITLE
Save checkpoints and wandb logs under Hydra output directory

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -55,3 +55,4 @@ training:
 # Logging settings
 logging:
   wandb_project: eq-damage
+  wandb_dir: wandb

--- a/earthquake_segmentation/train.py
+++ b/earthquake_segmentation/train.py
@@ -1,3 +1,5 @@
+import os
+from hydra.core.hydra_config import HydraConfig
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
@@ -18,9 +20,17 @@ from earthquake_segmentation.utils import (
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 def main(cfg: DictConfig):
     torch.manual_seed(cfg.seed)
+
+    run_dir = HydraConfig.get().runtime.output_dir
+    OmegaConf.set_readonly(cfg, False)
+    cfg.training.checkpoint_dir = os.path.join(run_dir, cfg.training.checkpoint_dir)
+    cfg.logging.wandb_dir = os.path.join(run_dir, cfg.logging.wandb_dir)
+    os.makedirs(cfg.training.checkpoint_dir, exist_ok=True)
+    os.makedirs(cfg.logging.wandb_dir, exist_ok=True)
     wandb.init(
         project=cfg.logging.wandb_project,
         config=OmegaConf.to_container(cfg, resolve=True),  ## type: ignore
+        dir=cfg.logging.wandb_dir,
     )
 
     train_ids, val_ids = make_splits(cfg)


### PR DESCRIPTION
## Summary
- keep checkpoint and wandb subdirs relative to Hydra output
- update training script to create paths inside Hydra run dir

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686abdd177f883258727b89ae1cf4226