### PR TITLE
Log building centroid overlays to W&B

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -82,3 +82,10 @@ logging:
   wandb_project: eq-damage
   wandb_dir: wandb
   wandb_name: conditional_deeplabv3plus_720_1e-4_cross_entropy
+
+evaluation:
+  building_metrics:
+    enabled: true
+    raise_on_missing: false
+    log_centroid_overlays: true
+    max_overlay_samples: 4

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,148 +1,18 @@
-import os
-from hydra.core.hydra_config import HydraConfig
-import torch
-from torch.utils.data import DataLoader
-from tqdm import tqdm
-import wandb
-from omegaconf import DictConfig, OmegaConf
+"""Entry-point script for training."""
+
+from __future__ import annotations
+
 import hydra
+from omegaconf import DictConfig
 
-from earthquake_segmentation.dataset import EarthquakeDamageDataset, make_splits
-from earthquake_segmentation.models.build_model import build_model
-from earthquake_segmentation.losses import build_loss
-from earthquake_segmentation.utils import (
-    MetricTracker,
-    save_checkpoint,
-    log_filtered_imgs,
-)
+from earthquake_segmentation.training_loop import run_training
 
 
-@hydra.main(version_base=None, config_path="conf", config_name="config")
-def main(cfg: DictConfig):
-    torch.manual_seed(cfg.seed)
-    run_dir = HydraConfig.get().runtime.output_dir
-    OmegaConf.set_readonly(cfg, False)
-    cfg.training.checkpoint_dir = os.path.join(run_dir, cfg.training.checkpoint_dir)
-    cfg.logging.wandb_dir = os.path.join(run_dir, cfg.logging.wandb_dir)
-    os.makedirs(cfg.training.checkpoint_dir, exist_ok=True)
-    os.makedirs(cfg.logging.wandb_dir, exist_ok=True)
-    wandb.init(
-        project=cfg.logging.wandb_project,
-        name=cfg.logging.wandb_name,
-        config=OmegaConf.to_container(cfg, resolve=True),  ## type: ignore
-        dir=cfg.logging.wandb_dir,
-    )
-
-    train_ids, val_ids = make_splits(cfg)
-    train_ds = EarthquakeDamageDataset(train_ids, cfg, mode="train")
-    val_ds = EarthquakeDamageDataset(val_ids, cfg, mode="val")
-
-    cuda = torch.cuda.is_available() and cfg.training.device == "cuda"
-
-    train_loader = DataLoader(
-        train_ds,
-        batch_size=cfg.training.batch_size,
-        shuffle=True,
-        num_workers=4,
-        pin_memory=cuda,
-        persistent_workers=cuda,
-        drop_last=True,          # <- ensures only full batches are used
-    )
-    val_loader = DataLoader(
-        val_ds,
-        batch_size=cfg.training.batch_size,
-        shuffle=False,
-        num_workers=4,
-        pin_memory=cuda,
-        persistent_workers=cuda,
-    )
-
-    # if feature_cols is non-empty, tell the model the conditional vector dimension
-    if cfg.data.feature_cols:
-        cfg.model.vec_dim = len(cfg.data.feature_cols)
-    device = torch.device(cfg.training.device if torch.cuda.is_available() else "cpu")
-    if device.type == "cuda":
-        torch.backends.cudnn.benchmark = True
-
-    model = build_model(cfg).to(device)
-    loss_fn = build_loss(cfg)
-    optimizer = torch.optim.AdamW(
-        model.parameters(), lr=cfg.training.lr, weight_decay=cfg.training.weight_decay
-    )
-
-    best_iou = 0.0
-    for epoch in range(1, cfg.training.epochs + 1):
-        model.train()
-        train_loss = 0.0
-        for imgs, masks, params, extras in tqdm(train_loader, desc="Train"):
-            imgs = imgs.to(device, non_blocking=cuda)
-            masks = masks.to(device, non_blocking=cuda)
-
-            optimizer.zero_grad()
-
-            # forward pass
-            if cfg.model.is_conditional and cfg.data.feature_cols:
-                params = params.to(device, non_blocking=cuda)
-                outputs = model(imgs, params)
-            else:
-                outputs = model(imgs)
-
-            loss = loss_fn(outputs, masks)
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.item()
-        train_loss /= len(train_loader)
-
-        model.eval()
-        tracker = MetricTracker(cfg.model.num_classes, device)
-        tracker.reset()
-
-        val_loss = 0.0
-        all_imgs, all_masks, all_preds = [], [], []
-        with torch.no_grad():
-            for imgs, masks, params, extras in tqdm(val_loader, desc="Val"):
-                imgs = imgs.to(device, non_blocking=cuda)
-                masks = masks.to(device, non_blocking=cuda)
-
-                # forward pass
-                if cfg.model.is_conditional and cfg.data.feature_cols:
-                    params = params.to(device, non_blocking=cuda)
-                    outputs = model(imgs, params)
-                else:
-                    outputs = model(imgs)
-
-                val_loss += loss_fn(outputs, masks).item()
-                preds = outputs.argmax(dim=1)
-                tracker.update(preds, masks)
-                all_imgs.extend(imgs.cpu())
-                all_masks.extend(masks.cpu())
-                all_preds.extend(preds.cpu())
-        val_loss /= len(val_loader)
-        val_iou = tracker.compute().item()
-
-        wandb.log(
-            {
-                "epoch": epoch,
-                "train_loss": train_loss,
-                "val_loss": val_loss,
-                "val_iou": val_iou,
-            }
-        )
-
-        log_filtered_imgs(all_imgs, all_masks, all_preds, epoch)
-
-        state = {
-            "epoch": epoch,
-            "model": model.state_dict(),
-            "optim": optimizer.state_dict(),
-            "val_iou": val_iou,
-        }
-        is_best = val_iou > best_iou
-        best_iou = max(val_iou, best_iou)
-        save_checkpoint(state, cfg, is_best)
-
-    wandb.finish()
+@hydra.main(version_base=None, config_path="../conf", config_name="config")
+def main(cfg: DictConfig) -> None:
+    run_training(cfg)
 
 
 if __name__ == "__main__":
     main()
+

--- a/src/earthquake_segmentation/building_metrics.py
+++ b/src/earthquake_segmentation/building_metrics.py
@@ -1,0 +1,204 @@
+"""Building-level metric helpers.
+
+This module centralises the logic needed to aggregate per-building
+predictions, compute derived statistics, and wire them into the
+training/validation loop.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from omegaconf import DictConfig, OmegaConf
+from sklearn.metrics import confusion_matrix, precision_recall_fscore_support
+import torch
+
+from .utils import accumulate_building_majority_labels
+
+
+SPATIAL_MISALIGNMENT_KEYWORDS = {
+    "crop",
+    "flip",
+    "rotate",
+    "transpose",
+    "perspective",
+    "affine",
+}
+
+
+def _iter_transform_names(transforms_cfg: Iterable) -> Iterable[str]:
+    """Yield augmentation names from a Hydra/OmegaConf list configuration."""
+
+    if transforms_cfg is None:
+        return []
+
+    for item in transforms_cfg:
+        container = item
+        if OmegaConf.is_config(item):
+            container = OmegaConf.to_container(item, resolve=True)
+        if isinstance(container, dict):
+            for name in container.keys():
+                if name:
+                    yield str(name)
+
+
+def _find_spatially_incompatible_transform(cfg: DictConfig) -> Optional[str]:
+    """Return the first validation transform that breaks building alignment, if any."""
+
+    val_transforms = getattr(cfg.augmentations, "val", [])
+    for name in _iter_transform_names(val_transforms):
+        lower_name = name.lower()
+        if any(keyword in lower_name for keyword in SPATIAL_MISALIGNMENT_KEYWORDS):
+            return name
+    return None
+
+
+def resolve_building_metrics_settings(cfg: DictConfig) -> Tuple[bool, bool]:
+    """Determine if building metrics should run and whether to raise on missing data."""
+
+    evaluation_cfg = getattr(cfg, "evaluation", None)
+    building_cfg = getattr(evaluation_cfg, "building_metrics", None)
+
+    enabled = bool(getattr(building_cfg, "enabled", False))
+    raise_on_missing = bool(getattr(building_cfg, "raise_on_missing", False))
+
+    if enabled:
+        incompatible = _find_spatially_incompatible_transform(cfg)
+        if incompatible:
+            warnings.warn(
+                "Disabling building-level metrics because validation augmentations include "
+                f"'{incompatible}', which changes spatial alignment relative to building polygons."
+            )
+            enabled = False
+
+    return enabled, raise_on_missing
+
+
+def collect_building_metrics_from_batch(
+    extras: Sequence[Optional[Dict[str, Optional[str]]]],
+    masks_cpu: torch.Tensor,
+    preds_cpu: torch.Tensor,
+    raise_on_missing: bool,
+) -> Tuple[List[int], List[int]]:
+    """Collect building-level targets/predictions for a batch."""
+
+    batch_targets: List[int] = []
+    batch_predictions: List[int] = []
+
+    for sample_idx, extra in enumerate(extras):
+        extra = extra or {}
+        building_path = extra.get("building_path")
+        label_path = extra.get("label_path")
+        uid = extra.get("uid", "unknown")
+
+        if not building_path or not os.path.exists(building_path):
+            message = f"Missing building annotations for UID {uid}."
+            if raise_on_missing:
+                raise FileNotFoundError(message)
+            warnings.warn(message)
+            continue
+
+        if not label_path or not os.path.exists(label_path):
+            message = f"Missing label raster for UID {uid}."
+            if raise_on_missing:
+                raise FileNotFoundError(message)
+            warnings.warn(message)
+            continue
+
+        try:
+            pairs = accumulate_building_majority_labels(
+                building_path,
+                label_path,
+                masks_cpu[sample_idx],
+                preds_cpu[sample_idx],
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            if raise_on_missing:
+                raise
+            warnings.warn(
+                f"Failed to compute building metrics for UID {uid}: {exc}"
+            )
+            continue
+
+        for target, prediction in pairs:
+            batch_targets.append(int(target))
+            batch_predictions.append(int(prediction))
+
+    return batch_targets, batch_predictions
+
+
+def compute_building_metric_statistics(
+    targets: Sequence[int], predictions: Sequence[int], num_classes: int
+) -> Optional[Dict[str, object]]:
+    """Return precision/recall/F1/support/confusion for building predictions."""
+
+    if not targets:
+        return None
+
+    labels = list(range(num_classes))
+    precision, recall, f1, support = precision_recall_fscore_support(
+        targets,
+        predictions,
+        labels=labels,
+        zero_division=0,
+    )
+    precision_macro, recall_macro, f1_macro, _ = precision_recall_fscore_support(
+        targets,
+        predictions,
+        labels=labels,
+        zero_division=0,
+        average="macro",
+    )
+    conf_mat = confusion_matrix(targets, predictions, labels=labels)
+
+    return {
+        "labels": labels,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "support": support,
+        "precision_macro": precision_macro,
+        "recall_macro": recall_macro,
+        "f1_macro": f1_macro,
+        "confusion": conf_mat,
+    }
+
+
+def update_log_with_building_metrics(
+    log_payload: Dict[str, object], stats: Dict[str, object]
+) -> None:
+    """Populate the log payload with building metric scalars."""
+
+    log_payload["building_precision_macro"] = stats["precision_macro"]
+    log_payload["building_recall_macro"] = stats["recall_macro"]
+    log_payload["building_f1_macro"] = stats["f1_macro"]
+
+    labels: List[int] = stats["labels"]  # type: ignore[assignment]
+    precision = stats["precision"]
+    recall = stats["recall"]
+    f1 = stats["f1"]
+    support = stats["support"]
+    conf_mat = stats["confusion"]
+
+    for idx, label in enumerate(labels):
+        log_payload[f"building_precision_class_{label}"] = float(precision[idx])
+        log_payload[f"building_recall_class_{label}"] = float(recall[idx])
+        log_payload[f"building_f1_class_{label}"] = float(f1[idx])
+        log_payload[f"building_support_class_{label}"] = int(support[idx])
+        for jdx, pred_label in enumerate(labels):
+            log_payload[
+                f"building_confusion/label_{label}_pred_{pred_label}"
+            ] = int(
+                conf_mat[idx, jdx]
+            )
+
+
+__all__ = [
+    "collect_building_metrics_from_batch",
+    "compute_building_metric_statistics",
+    "resolve_building_metrics_settings",
+    "update_log_with_building_metrics",
+]
+

--- a/src/earthquake_segmentation/training_loop.py
+++ b/src/earthquake_segmentation/training_loop.py
@@ -1,0 +1,267 @@
+"""End-to-end training loop orchestration."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+import wandb
+
+from .building_metrics import (
+    collect_building_metrics_from_batch,
+    compute_building_metric_statistics,
+    resolve_building_metrics_settings,
+    update_log_with_building_metrics,
+)
+from .dataset import EarthquakeDamageDataset, make_splits
+from .losses import build_loss
+from .models.build_model import build_model
+from .utils import (
+    MetricTracker,
+    log_building_centroid_overlays,
+    log_filtered_imgs,
+    save_checkpoint,
+)
+
+
+def _initialise_wandb(cfg: DictConfig) -> None:
+    wandb.init(
+        project=cfg.logging.wandb_project,
+        name=cfg.logging.wandb_name,
+        config=OmegaConf.to_container(cfg, resolve=True),  # type: ignore[arg-type]
+        dir=cfg.logging.wandb_dir,
+    )
+
+
+def _create_dataloaders(
+    cfg: DictConfig, cuda: bool
+) -> tuple[DataLoader, DataLoader]:
+    train_ids, val_ids = make_splits(cfg)
+    train_ds = EarthquakeDamageDataset(train_ids, cfg, mode="train")
+    val_ds = EarthquakeDamageDataset(val_ids, cfg, mode="val")
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg.training.batch_size,
+        shuffle=True,
+        num_workers=4,
+        pin_memory=cuda,
+        persistent_workers=cuda,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=cfg.training.batch_size,
+        shuffle=False,
+        num_workers=4,
+        pin_memory=cuda,
+        persistent_workers=cuda,
+    )
+    return train_loader, val_loader
+
+
+def _prepare_directories(cfg: DictConfig, run_dir: str) -> None:
+    cfg.training.checkpoint_dir = os.path.join(run_dir, cfg.training.checkpoint_dir)
+    cfg.logging.wandb_dir = os.path.join(run_dir, cfg.logging.wandb_dir)
+    os.makedirs(cfg.training.checkpoint_dir, exist_ok=True)
+    os.makedirs(cfg.logging.wandb_dir, exist_ok=True)
+
+
+def _collect_building_metrics_for_epoch(
+    building_metrics_enabled: bool,
+    raise_on_missing: bool,
+    building_targets: List[int],
+    building_predictions: List[int],
+    extras: Sequence[Optional[Dict[str, Optional[str]]]],
+    masks_cpu: torch.Tensor,
+    preds_cpu: torch.Tensor,
+) -> None:
+    if not building_metrics_enabled:
+        return
+
+    batch_targets, batch_preds = collect_building_metrics_from_batch(
+        extras,
+        masks_cpu,
+        preds_cpu,
+        raise_on_missing,
+    )
+    building_targets.extend(batch_targets)
+    building_predictions.extend(batch_preds)
+
+
+def run_training(cfg: DictConfig) -> None:
+    torch.manual_seed(cfg.seed)
+    run_dir = HydraConfig.get().runtime.output_dir
+    OmegaConf.set_readonly(cfg, False)
+
+    _prepare_directories(cfg, run_dir)
+    _initialise_wandb(cfg)
+
+    if cfg.data.feature_cols:
+        cfg.model.vec_dim = len(cfg.data.feature_cols)
+
+    cuda_available = torch.cuda.is_available() and cfg.training.device == "cuda"
+    device = torch.device(cfg.training.device if torch.cuda.is_available() else "cpu")
+    if device.type == "cuda":
+        torch.backends.cudnn.benchmark = True
+
+    train_loader, val_loader = _create_dataloaders(cfg, cuda_available)
+
+    model = build_model(cfg).to(device)
+    loss_fn = build_loss(cfg)
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=cfg.training.lr, weight_decay=cfg.training.weight_decay
+    )
+
+    building_metrics_enabled_global, raise_on_missing_global = (
+        resolve_building_metrics_settings(cfg)
+    )
+    building_cfg = getattr(getattr(cfg, "evaluation", {}), "building_metrics", {})
+    log_centroid_overlays = bool(getattr(building_cfg, "log_centroid_overlays", False))
+    max_overlay_samples = int(getattr(building_cfg, "max_overlay_samples", 4))
+
+    best_iou = 0.0
+    for epoch in range(1, cfg.training.epochs + 1):
+        model.train()
+        train_loss = 0.0
+        for imgs, masks, params, _extras in tqdm(train_loader, desc="Train"):
+            imgs = imgs.to(device, non_blocking=cuda_available)
+            masks = masks.to(device, non_blocking=cuda_available)
+
+            optimizer.zero_grad()
+
+            if cfg.model.is_conditional and cfg.data.feature_cols:
+                params = params.to(device, non_blocking=cuda_available)
+                outputs = model(imgs, params)
+            else:
+                outputs = model(imgs)
+
+            loss = loss_fn(outputs, masks)
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
+        train_loss /= len(train_loader)
+
+        model.eval()
+        tracker = MetricTracker(cfg.model.num_classes, device)
+        tracker.reset()
+
+        val_loss = 0.0
+        all_imgs, all_masks, all_preds = [], [], []
+        building_targets: List[int] = []
+        building_predictions: List[int] = []
+        building_overlay_samples: List[
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor, str, str]
+        ] = []
+        building_metrics_enabled = building_metrics_enabled_global
+        raise_on_missing = raise_on_missing_global
+
+        with torch.no_grad():
+            for imgs, masks, params, extras in tqdm(val_loader, desc="Val"):
+                imgs = imgs.to(device, non_blocking=cuda_available)
+                masks = masks.to(device, non_blocking=cuda_available)
+
+                if cfg.model.is_conditional and cfg.data.feature_cols:
+                    params = params.to(device, non_blocking=cuda_available)
+                    outputs = model(imgs, params)
+                else:
+                    outputs = model(imgs)
+
+                val_loss += loss_fn(outputs, masks).item()
+                preds = outputs.argmax(dim=1)
+                tracker.update(preds, masks)
+
+                imgs_cpu = imgs.cpu()
+                masks_cpu = masks.cpu()
+                preds_cpu = preds.cpu()
+                all_imgs.extend(imgs_cpu)
+                all_masks.extend(masks_cpu)
+                all_preds.extend(preds_cpu)
+
+                _collect_building_metrics_for_epoch(
+                    building_metrics_enabled,
+                    raise_on_missing,
+                    building_targets,
+                    building_predictions,
+                    extras,
+                    masks_cpu,
+                    preds_cpu,
+                )
+
+                if (
+                    log_centroid_overlays
+                    and len(building_overlay_samples) < max_overlay_samples
+                ):
+                    for sample_idx, extra in enumerate(extras):
+                        extra = extra or {}
+                        building_path = extra.get("building_path")
+                        if not building_path or not os.path.exists(building_path):
+                            continue
+                        uid = extra.get("uid", f"sample_{len(building_overlay_samples)}")
+                        building_overlay_samples.append(
+                            (
+                                imgs_cpu[sample_idx],
+                                masks_cpu[sample_idx],
+                                preds_cpu[sample_idx],
+                                building_path,
+                                uid,
+                            )
+                        )
+                        if len(building_overlay_samples) >= max_overlay_samples:
+                            break
+
+        val_loss /= len(val_loader)
+        val_iou = tracker.compute().item()
+
+        log_payload: Dict[str, object] = {
+            "epoch": epoch,
+            "train_loss": train_loss,
+            "val_loss": val_loss,
+            "val_iou": val_iou,
+        }
+
+        building_stats = None
+        if building_metrics_enabled:
+            building_stats = compute_building_metric_statistics(
+                building_targets,
+                building_predictions,
+                cfg.model.num_classes,
+            )
+
+        if building_stats:
+            print(
+                "[Val] Building metrics | "
+                f"Precision (macro): {building_stats['precision_macro']:.4f} | "
+                f"Recall (macro): {building_stats['recall_macro']:.4f} | "
+                f"F1 (macro): {building_stats['f1_macro']:.4f}"
+            )
+            print("[Val] Building confusion matrix:\n", building_stats["confusion"])
+            update_log_with_building_metrics(log_payload, building_stats)
+        elif building_metrics_enabled:
+            print("[Val] Building metrics requested but no predictions were collected.")
+
+        wandb.log(log_payload)
+        log_filtered_imgs(all_imgs, all_masks, all_preds, epoch)
+        if log_centroid_overlays:
+            log_building_centroid_overlays(building_overlay_samples, epoch)
+
+        state = {
+            "epoch": epoch,
+            "model": model.state_dict(),
+            "optim": optimizer.state_dict(),
+            "val_iou": val_iou,
+        }
+        is_best = val_iou > best_iou
+        best_iou = max(val_iou, best_iou)
+        save_checkpoint(state, cfg, is_best)
+
+    wandb.finish()
+
+
+__all__ = ["run_training"]
+

--- a/src/earthquake_segmentation/utils.py
+++ b/src/earthquake_segmentation/utils.py
@@ -1,11 +1,17 @@
+import json
 import os
 import shutil
 import tempfile
+import warnings
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
 import torch
 import wandb
+from rasterio import features
+import rasterio
+from rasterio.transform import Affine
 from torchmetrics import JaccardIndex
-from typing import Optional
-import numpy as np
 
 
 
@@ -145,6 +151,222 @@ def log_images(
                 f"input/{i}": wandb.Image(img_np, caption=f"Epoch {epoch} Input"),
                 f"mask/{i}": wandb.Image(mask_rgb, caption=f"Epoch {epoch} GT"),
                 f"pred/{i}": wandb.Image(pred_rgb, caption=f"Epoch {epoch} Pred"),
+                "epoch": epoch,
+            }
+        )
+
+
+def _load_building_geometries(building_json_path: str) -> Sequence[Tuple[dict, dict]]:
+    """Return geometry/property pairs from a building GeoJSON file."""
+
+    with open(building_json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if isinstance(data, dict) and "features" in data:
+        features_iter = data["features"]
+    elif isinstance(data, list):
+        features_iter = data
+    else:
+        raise ValueError(
+            f"Unsupported building annotation format in '{building_json_path}'."
+        )
+
+    geometries: List[Tuple[dict, dict]] = []
+    for feature in features_iter:
+        if not feature:
+            continue
+        geometry = feature.get("geometry") if isinstance(feature, dict) else feature
+        properties = feature.get("properties", {}) if isinstance(feature, dict) else {}
+        if geometry is None:
+            continue
+        geometries.append((geometry, properties))
+    return geometries
+
+
+def _load_building_centroids(building_json_path: str) -> List[Tuple[float, float]]:
+    """Extract centroid column/row pairs from a building GeoJSON file."""
+
+    centroids: List[Tuple[float, float]] = []
+    for _geometry, properties in _load_building_geometries(building_json_path):
+        if not properties:
+            continue
+        col = properties.get("centroid_col")
+        row = properties.get("centroid_row")
+        if col is None or row is None:
+            continue
+        try:
+            centroids.append((float(col), float(row)))
+        except (TypeError, ValueError):
+            continue
+    return centroids
+
+
+def accumulate_building_majority_labels(
+    building_json_path: str,
+    label_raster_path: str,
+    gt_mask: torch.Tensor,
+    pred_mask: torch.Tensor,
+) -> List[Tuple[int, int]]:
+    """
+    Rasterize building polygons and compute majority GT/pred labels per building.
+
+    Returns a list of ``(target, prediction)`` tuples, one per building polygon.
+    """
+
+    if gt_mask.shape != pred_mask.shape:
+        raise ValueError(
+            "Ground truth and prediction masks must share the same spatial shape."
+        )
+
+    gt_np = gt_mask.detach().cpu().numpy()
+    pred_np = pred_mask.detach().cpu().numpy()
+
+    geometries = _load_building_geometries(building_json_path)
+    if not geometries:
+        warnings.warn(f"No building geometries found in '{building_json_path}'.")
+        return []
+
+    with rasterio.open(label_raster_path) as src:
+        transform = src.transform
+        out_shape = (src.height, src.width)
+
+    # Ensure the rasterized map aligns with the tensors. If shapes diverge we
+    # rescale the affine transform to the tensor's spatial shape.
+    if out_shape != gt_np.shape:
+        scale_y = out_shape[0] / gt_np.shape[0]
+        scale_x = out_shape[1] / gt_np.shape[1]
+        transform = transform * Affine.scale(scale_x, scale_y)
+        out_shape = gt_np.shape
+
+    shapes: List[Tuple[dict, int]] = []
+    labels_and_properties: List[Tuple[int, dict]] = []
+    for geometry, properties in geometries:
+        if geometry is None:
+            continue
+        label = len(shapes) + 1
+        shapes.append((geometry, label))
+        labels_and_properties.append((label, properties or {}))
+    if not shapes:
+        return []
+
+    building_index = features.rasterize(
+        shapes,
+        out_shape=out_shape,
+        transform=transform,
+        fill=0,
+        dtype="int32",
+        all_touched=True,
+    )
+
+    results: List[Tuple[int, int]] = []
+    for label, _ in labels_and_properties:
+        mask = building_index == label
+        if not mask.any():
+            continue
+        gt_vals = gt_np[mask]
+        pred_vals = pred_np[mask]
+        if gt_vals.size == 0 or pred_vals.size == 0:
+            continue
+        gt_majority = int(np.bincount(gt_vals).argmax())
+        pred_majority = int(np.bincount(pred_vals).argmax())
+        results.append((gt_majority, pred_majority))
+
+    return results
+
+
+def _draw_cross(
+    canvas: np.ndarray, row: int, col: int, color: Sequence[int], half_size: int = 2
+) -> None:
+    """Draw a small cross centred on ``(row, col)`` on ``canvas`` inplace."""
+
+    if canvas.ndim != 3:
+        raise ValueError("Canvas must be an HxWxC array.")
+
+    height, width = canvas.shape[:2]
+    if not (0 <= row < height and 0 <= col < width):
+        return
+
+    row_range = range(max(0, row - half_size), min(height, row + half_size + 1))
+    col_range = range(max(0, col - half_size), min(width, col + half_size + 1))
+
+    for r in row_range:
+        canvas[r, col] = color
+    for c in col_range:
+        canvas[row, c] = color
+
+
+def _build_centroid_overlay_panel(
+    image: torch.Tensor,
+    mask: torch.Tensor,
+    prediction: torch.Tensor,
+    centroids: Sequence[Tuple[float, float]],
+) -> Optional[np.ndarray]:
+    """Return an RGB panel visualising centroids on image/GT/prediction."""
+
+    if not centroids:
+        return None
+
+    img = denormalize_image(image).permute(1, 2, 0).cpu().numpy()
+    mask_np = mask.cpu().numpy().astype(np.int64)
+    pred_np = prediction.cpu().numpy().astype(np.int64)
+
+    cmap = np.array(
+        [
+            [0, 0, 0],
+            [0, 255, 0],
+            [255, 255, 0],
+            [255, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    mask_rgb = cmap[np.clip(mask_np, 0, len(cmap) - 1)]
+    pred_rgb = cmap[np.clip(pred_np, 0, len(cmap) - 1)]
+
+    overlay_color = np.array([255, 0, 255], dtype=np.uint8)
+
+    image_overlay = img.copy()
+    mask_overlay = mask_rgb.copy()
+    pred_overlay = pred_rgb.copy()
+
+    for row_f, col_f in centroids:
+        row = int(round(row_f))
+        col = int(round(col_f))
+        _draw_cross(image_overlay, row, col, overlay_color)
+        _draw_cross(mask_overlay, row, col, overlay_color)
+        _draw_cross(pred_overlay, row, col, overlay_color)
+
+    return np.concatenate([image_overlay, mask_overlay, pred_overlay], axis=1)
+
+
+def log_building_centroid_overlays(
+    samples: Sequence[Tuple[torch.Tensor, torch.Tensor, torch.Tensor, str, str]],
+    epoch: int,
+) -> None:
+    """Log W&B images showing building centroids on images/masks/predictions."""
+
+    if not samples:
+        return
+
+    for idx, (image, mask, prediction, building_json, uid) in enumerate(samples):
+        if not os.path.exists(building_json):
+            warnings.warn(
+                f"Skipping centroid overlay for UID {uid}: '{building_json}' not found."
+            )
+            continue
+
+        centroids = _load_building_centroids(building_json)
+        panel = _build_centroid_overlay_panel(image, mask, prediction, centroids)
+        if panel is None:
+            warnings.warn(
+                f"Skipping centroid overlay for UID {uid}: no centroid coordinates available."
+            )
+            continue
+
+        caption = f"Epoch {epoch} UID {uid}"
+        wandb.log(
+            {
+                f"building_centroids/{uid}_{idx}": wandb.Image(panel, caption=caption),
                 "epoch": epoch,
             }
         )


### PR DESCRIPTION
## Summary
- add configuration flags to control building centroid overlay logging during validation
- capture validation samples with building annotations and log overlay panels to W&B alongside standard metrics
- implement utilities to extract building centroids and render combined image/mask/prediction panels

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68da065dcf388325a561d558203151f3