### PR TITLE
Add building-aware loss and dataset support

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -64,7 +64,12 @@ model:
 
 # Loss configuration
 loss:
-  name: cross_entropy # options: cross_entropy, dice, cross_entropy_dice
+  name: building_pooled # options: cross_entropy, dice, cross_entropy_dice, building_pooled
+  pixel_loss: cross_entropy
+  pixel_weight: 1.0
+  building_weight: 1.0
+  building_background_id: 0
+  building_ignore_index: null
   dice_weight: 1.0
 
 # Training hyperparameters

--- a/scripts/visualizations/visualize_dataset.py
+++ b/scripts/visualizations/visualize_dataset.py
@@ -23,7 +23,7 @@ def visualize(cfg: DictConfig):
     # Load data
     ds = EarthquakeDamageDataset(prefixes, cfg, mode=stage)
     loader = DataLoader(ds, batch_size=n, shuffle=True)
-    imgs, masks, _, extras = next(iter(loader))
+    imgs, masks, building_ids, _, extras = next(iter(loader))
 
     # Plot images and masks
     # Ensure axes is always a 2D array so indexing works when n == 1

--- a/src/earthquake_segmentation/losses.py
+++ b/src/earthquake_segmentation/losses.py
@@ -1,15 +1,29 @@
+from typing import Callable, Optional
+
 import torch
 import torch.nn.functional as F
 
 
 def dice_loss(
-    pred: torch.Tensor, target: torch.Tensor, eps: float = 1e-6
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    eps: float = 1e-6,
+    ignore_index: Optional[int] = None,
 ) -> torch.Tensor:
     """Compute Dice loss for multi-class segmentation."""
     pred = torch.softmax(pred, dim=1)
+    target_tensor = target
+    if ignore_index is not None:
+        valid_mask = target != ignore_index
+        target_tensor = torch.where(
+            valid_mask, target, torch.zeros_like(target, device=target.device)
+        )
+        pred = pred * valid_mask.unsqueeze(1)
     target_one_hot = (
-        F.one_hot(target, num_classes=pred.shape[1]).permute(0, 3, 1, 2).float()
+        F.one_hot(target_tensor, num_classes=pred.shape[1]).permute(0, 3, 1, 2).float()
     )
+    if ignore_index is not None:
+        target_one_hot = target_one_hot * valid_mask.unsqueeze(1)
     dims = (1, 2, 3)
     intersection = (pred * target_one_hot).sum(dims)
     union = pred.sum(dims) + target_one_hot.sum(dims)
@@ -17,20 +31,114 @@ def dice_loss(
     return 1 - dice.mean()
 
 
-def build_loss(cfg):
-    """Return a loss function based on the config."""
-    name = cfg.loss.name
+def _build_pixel_loss(
+    cfg, name: str, ignore_index: Optional[int]
+) -> Callable[..., torch.Tensor]:
     if name == "cross_entropy":
-        return lambda pred, target: F.cross_entropy(pred, target)
+        return lambda pred, target, **_: F.cross_entropy(
+            pred, target, ignore_index=ignore_index
+        )
     if name == "dice":
-        return lambda pred, target: dice_loss(pred, target)
+        return lambda pred, target, **_: dice_loss(
+            pred, target, ignore_index=ignore_index
+        )
     if name == "cross_entropy_dice":
         weight = cfg.loss.get("dice_weight", 1.0)
 
-        def loss_fn(pred, target):
-            ce = F.cross_entropy(pred, target)
-            d = dice_loss(pred, target)
+        def loss_fn(pred, target, **_):
+            ce = F.cross_entropy(pred, target, ignore_index=ignore_index)
+            d = dice_loss(pred, target, ignore_index=ignore_index)
             return ce + weight * d
 
         return loss_fn
+    raise ValueError(f"Unknown pixel loss: {name}")
+
+
+class BuildingPooledLoss:
+    def __init__(
+        self,
+        pixel_loss: Callable[..., torch.Tensor],
+        pixel_weight: float,
+        building_weight: float,
+        ignore_index: Optional[int],
+        background_id: int,
+        eps: float = 1e-12,
+    ) -> None:
+        self.pixel_loss = pixel_loss
+        self.pixel_weight = float(pixel_weight)
+        self.building_weight = float(building_weight)
+        self.ignore_index = ignore_index
+        self.background_id = background_id
+        self.eps = eps
+
+    def _building_component(
+        self, pred: torch.Tensor, target: torch.Tensor, building_ids: torch.Tensor
+    ) -> torch.Tensor:
+        probs = torch.softmax(pred, dim=1)
+        total_loss = pred.new_zeros(())
+        building_count = 0
+        num_classes = pred.shape[1]
+        for batch_idx in range(pred.shape[0]):
+            sample_buildings = torch.unique(building_ids[batch_idx])
+            if sample_buildings.numel() == 0:
+                continue
+            if self.background_id is not None:
+                sample_buildings = sample_buildings[
+                    sample_buildings != self.background_id
+                ]
+            for building_id in sample_buildings:
+                mask = building_ids[batch_idx] == building_id
+                if self.ignore_index is not None:
+                    mask = mask & (target[batch_idx] != self.ignore_index)
+                if not torch.any(mask):
+                    continue
+                target_vals = target[batch_idx][mask]
+                counts = torch.bincount(target_vals, minlength=num_classes)
+                majority_class = torch.argmax(counts)
+                building_probs = probs[batch_idx, :, mask].mean(dim=1)
+                loss = -torch.log(
+                    building_probs[majority_class].clamp_min(self.eps)
+                )
+                total_loss = total_loss + loss
+                building_count += 1
+        if building_count == 0:
+            return pred.new_zeros(())
+        return total_loss / building_count
+
+    def __call__(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        *,
+        building_ids: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        pixel_term = self.pixel_loss(pred, target)
+        if self.building_weight == 0:
+            return self.pixel_weight * pixel_term
+        if building_ids is None:
+            raise ValueError("building_ids must be provided for building-pooled loss")
+        building_term = self._building_component(pred, target, building_ids)
+        return self.pixel_weight * pixel_term + self.building_weight * building_term
+
+
+def build_loss(cfg):
+    """Return a loss function based on the config."""
+    name = cfg.loss.name
+    ignore_index = cfg.loss.get("ignore_index", None)
+    if name in {"cross_entropy", "dice", "cross_entropy_dice"}:
+        return _build_pixel_loss(cfg, name, ignore_index)
+    if name == "building_pooled":
+        pixel_loss_name = cfg.loss.get("pixel_loss", "cross_entropy")
+        pixel_loss = _build_pixel_loss(cfg, pixel_loss_name, ignore_index)
+        pixel_weight = cfg.loss.get("pixel_weight", 1.0)
+        building_weight = cfg.loss.get("building_weight", 1.0)
+        background_id = cfg.loss.get("building_background_id", 0)
+        building_ignore_index = cfg.loss.get("building_ignore_index", ignore_index)
+        return BuildingPooledLoss(
+            pixel_loss=pixel_loss,
+            pixel_weight=pixel_weight,
+            building_weight=building_weight,
+            ignore_index=building_ignore_index,
+            background_id=background_id,
+        )
     raise ValueError(f"Unknown loss: {name}")

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,100 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+from omegaconf import OmegaConf
+
+from earthquake_segmentation.losses import build_loss
+
+
+def _make_building_loss(cfg_dict):
+    cfg = OmegaConf.create({"loss": cfg_dict})
+    return build_loss(cfg)
+
+
+def test_building_pooled_loss_combines_pixel_and_building_terms():
+    probs = torch.tensor(
+        [
+            [
+                [0.1, 0.2],
+                [0.6, 0.1],
+            ],
+            [
+                [0.8, 0.7],
+                [0.2, 0.4],
+            ],
+            [
+                [0.1, 0.1],
+                [0.2, 0.5],
+            ],
+        ],
+        dtype=torch.float32,
+    )
+    logits = torch.log(probs).unsqueeze(0)
+    target = torch.tensor([[1, 1], [0, 2]], dtype=torch.long).unsqueeze(0)
+    building_ids = torch.tensor([[1, 1], [0, 2]], dtype=torch.long).unsqueeze(0)
+
+    loss_fn = _make_building_loss(
+        {
+            "name": "building_pooled",
+            "pixel_loss": "cross_entropy",
+            "pixel_weight": 1.0,
+            "building_weight": 0.5,
+            "building_background_id": 0,
+        }
+    )
+
+    loss = loss_fn(logits, target, building_ids=building_ids)
+
+    pixel_loss = torch.nn.functional.cross_entropy(logits, target)
+    building_probs_majority = torch.tensor([
+        torch.mean(torch.tensor([0.8, 0.7])),
+        torch.tensor(0.5),
+    ])
+    expected_building_loss = -torch.log(building_probs_majority).mean()
+    expected = pixel_loss + 0.5 * expected_building_loss
+    assert torch.allclose(loss, expected, atol=1e-6)
+
+
+def test_building_pooled_loss_skips_unlabeled_buildings():
+    logits = torch.zeros((1, 2, 2, 2), dtype=torch.float32, requires_grad=True)
+    target = torch.full((1, 2, 2), -1, dtype=torch.long)
+    building_ids = torch.tensor([[1, 1], [2, 2]], dtype=torch.long).unsqueeze(0)
+
+    loss_fn = _make_building_loss(
+        {
+            "name": "building_pooled",
+            "pixel_loss": "cross_entropy",
+            "pixel_weight": 0.0,
+            "building_weight": 1.0,
+            "building_background_id": 0,
+            "building_ignore_index": -1,
+        }
+    )
+
+    loss = loss_fn(logits, target, building_ids=building_ids)
+    assert torch.allclose(loss, torch.tensor(0.0))
+
+
+def test_building_pooled_loss_handles_batches_with_missing_buildings():
+    logits = torch.zeros((2, 2, 2, 2), dtype=torch.float32, requires_grad=True)
+    target = torch.zeros((2, 2, 2), dtype=torch.long)
+    building_ids = torch.tensor(
+        [
+            [[0, 0], [1, 1]],
+            [[0, 0], [0, 0]],
+        ],
+        dtype=torch.long,
+    )
+
+    loss_fn = _make_building_loss(
+        {
+            "name": "building_pooled",
+            "pixel_loss": "cross_entropy",
+            "pixel_weight": 1.0,
+            "building_weight": 1.0,
+            "building_background_id": 0,
+        }
+    )
+
+    loss = loss_fn(logits, target, building_ids=building_ids)
+    assert torch.isfinite(loss)


### PR DESCRIPTION
## Summary
- extend the dataset pipeline to expose building instance rasters alongside masks
- introduce a building-pooled loss that blends configurable pixel and building terms and wire it through training and config
- add smoke tests covering pooled loss edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1143164c83259dadef328fab408c